### PR TITLE
fix(ProductGrid): display price with profit instead of base price

### DIFF
--- a/resources/js/Components/store/ProductGrid.jsx
+++ b/resources/js/Components/store/ProductGrid.jsx
@@ -682,7 +682,7 @@ const Card = React.memo(({ product }) => {
           <span className={`text-xl font-bold transition-colors duration-300 ${
             isDarkMode ? 'text-blue-400' : 'text-blue-600'
           }`}>
-            {formatPrice(product.price)}
+            {formatPrice(product.priceWithProfit)}
           </span>
         </div>
       </div>


### PR DESCRIPTION
The product card was showing the base price instead of the price with profit. Updated to display the correct priceWithProfit value.