### PR TITLE
fix(product): display profit price instead of cost price

### DIFF
--- a/resources/js/Components/product/RelatedProducts.jsx
+++ b/resources/js/Components/product/RelatedProducts.jsx
@@ -491,7 +491,7 @@ const RelatedProducts = ({ productId, currentProductSubcategoryId }) => {
                         {/* Precio y SKU */}
                         <div className="border-t border-slate-600 pt-3">
                             <div className="flex justify-between items-center mb-2">
-                                <span className="text-2xl font-bold text-blue-400">{formatPrice(product.precio_sin_ganancia)}</span>
+                                <span className="text-2xl font-bold text-blue-400">{formatPrice(product.precio_ganancia)}</span>
                             </div>
                             <div className="text-xs text-gray-400">
                                 SKU: {product.sku}

--- a/resources/js/Components/product/SubcategoryProducts.jsx
+++ b/resources/js/Components/product/SubcategoryProducts.jsx
@@ -187,7 +187,7 @@ const SubcategoryProducts = ({ productId, currentProductSubcategoryId }) => {
                         {/* Precio y SKU */}
                         <div className="border-t border-slate-600 pt-3">
                             <div className="flex justify-between items-center mb-2">
-                                <span className="text-2xl font-bold text-blue-400">{formatPrice(product.precio_sin_ganancia)}</span>
+                                <span className="text-2xl font-bold text-blue-400">{formatPrice(product.precio_ganancia)}</span>
                             </div>
                             <div className="text-xs text-gray-400">
                                 SKU: {product.sku}


### PR DESCRIPTION
Update product price display to show precio_ganancia (profit price) instead of precio_sin_ganancia (cost price) in both RelatedProducts and SubcategoryProducts components to reflect the correct pricing to customers.